### PR TITLE
Add vscode.json for omarchy automatic theme switching

### DIFF
--- a/ghostty.conf
+++ b/ghostty.conf
@@ -1,0 +1,23 @@
+
+palette = 0=#073642
+palette = 1=#dc322f
+palette = 2=#859900
+palette = 3=#b58900
+palette = 4=#268bd2
+palette = 5=#d33682
+palette = 6=#2aa198
+palette = 7=#eee8d5
+palette = 8=#002b36
+palette = 9=#cb4b16
+palette = 10=#586e75
+palette = 11=#657b83
+palette = 12=#839496
+palette = 13=#6c71c4
+palette = 14=#93a1a1
+palette = 15=#fdf6e3
+background = #fdf6e3
+foreground = #586e75
+cursor-color = #708284
+cursor-text = #002831
+selection-background = #214283
+selection-foreground = #d2d8d9

--- a/vscode.json
+++ b/vscode.json
@@ -1,0 +1,4 @@
+{
+  "name": "Solarized Light+",
+  "extension": "ryanolsonx.solarized"
+}


### PR DESCRIPTION
## Summary
- Adds `vscode.json` to enable automatic VSCode theme switching when using omarchy
- Uses the `ryanolsonx.solarized` extension with "Solarized Light+" theme

## Test plan
- [ ] Install the solarized extension in VSCode: `ryanolsonx.solarized`
- [ ] Verify omarchy theme switching applies the VSCode theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)